### PR TITLE
[Fix] Avoid Shared Memory OOM on sm86 for HeadDim=128 by reducing block size

### DIFF
--- a/flash_moba/flash_moba_interface.py
+++ b/flash_moba/flash_moba_interface.py
@@ -38,6 +38,13 @@ def decide_lg_block_m(top_k: int, chunk_size: int, seqlen: int, causal: bool = F
     else:
         lg_block_m = 1024
 
+    # [Optimization] Hardware-aware cap for A6000/3090/4090 to avoid Shared Memory OOM
+    if torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability()
+        # sm86 (A6000, 3090) and sm89 (4090, L40) have smaller shared memory than A100 (sm80)
+        if major == 8 and minor > 0:
+            lg_block_m = min(lg_block_m, 512)
+
     return lg_block_m
 
 ##########################################################################################################################


### PR DESCRIPTION
This PR fixes a Shared Memory OOM issue in the `flash_moba` forward kernels for `HeadDim=128` on Ampere consumer GPUs (e.g., RTX A6000, RTX 3090, RTX 4090), which manifests as a `CUDA error: invalid argument` at kernel launch time.

Related Issue:
Fixes #3 

Description:
The current forward kernel configuration for `HeadDim=128` uses a logical block size `kMxLgBlockM = 1024`. On Ampere data center GPUs like A100 (sm80), this works because the per-SM shared memory limit is 164 KB. However, on Ampere consumer GPUs such as RTX A6000 / 3090 / 4090 (sm86/sm89), the shared memory per SM is limited to 100 KB.

For `HeadDim=128` and `kMxLgBlockM = 1024`, the combined shared memory required by the forward kernel (output, KV, row stats, Q, plus indices/overhead) exceeds 100 KB, causing the kernel launch to fail with:

```text
RuntimeError: CUDA error: invalid argument
````

This bug does not show up on A100 but reproduces reliably on RTX A6000 when using `HeadDim=128` in `flash_moba_attn_varlen_func`.

This PR makes the forward kernel selection hardware-aware for sm8x architectures and caps the logical block size in the Python interface so that the requested configuration never exceeds the shared memory budget on these GPUs, while preserving the original configuration on A100/H100.

Changes:

csrc/flash_moba/src/flash_fwd_launch_template.h:

* Detect the compute capability and classify sm8x devices via:

  * `auto [cc_major, cc_minor] = get_compute_capability(get_current_device());`
  * `bool is_sm8x = cc_major == 8 && cc_minor > 0;`
* For `run_moba_fwd_hdim128`:

  * Use `kMxLgBlockM = 512` instead of `1024` on sm8x for the non-dropout path:

    * Non-causal: `Flash_moba_fwd_kernel_traits<Headdim, 128, 32, 4, 512, ...>`
    * Causal: `Flash_moba_fwd_kernel_traits<Headdim, 64, 64, 4, 512, ...>`
  * For the dropout path:

    * Dispatch with `kMxLgBlockM = 512` on sm8x.
    * Keep using `kMxLgBlockM = 1024` on non-sm8x architectures.
* Preserve the existing `kMxLgBlockM = 1024` configuration for A100/H100 and other architectures, so behavior and performance on those GPUs remain unchanged.

flash_moba/flash_moba_interface.py:

* After computing `lg_block_m` from the sparsity heuristic, add a hardware-aware cap for sm8x:

  * Query the device capability via `torch.cuda.get_device_capability()`.
  * For devices with `major == 8 and minor > 0` (sm86, sm89), clamp `lg_block_m` to a maximum of `512`.
* This ensures the Python interface never requests a logical block size that would exceed the shared memory limit of sm8x kernels, and matches the updated C++ dispatch behavior.

Environment / Testing:

* GPU: NVIDIA RTX A6000 (sm86)
* Torch: 2.7.0+cu128
* FlashMoBA: latest `main` branch
* Verified that:

  * `flash_moba_attn_varlen_func` with `HeadDim=128` runs without `CUDA error: invalid argument` on RTX A6000.
  * The configuration logic remains unchanged for non-sm8x GPUs (e.g., A100).